### PR TITLE
fix cmake error in json linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,4 +54,4 @@ add_subdirectory(extern/tinyxml2/)
 
 # add json
 set(json_BUILD_TESTING OFF)
-add_subdirectory(extern/json)
+add_subdirectory(extern/json/)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,4 +15,4 @@ if(GUROBI_FOUND)
 endif()
 
 target_link_libraries(${PROJECT_NAME} INTERFACE tinyxml2::tinyxml2)
-target_link_libraries(${PROJECT_NAME} INTERFACE nlohmann::json)
+target_link_libraries(${PROJECT_NAME} INTERFACE nlohmann)


### PR DESCRIPTION
nlohmann::json was not found as an interface. The correct seems to be just to interface to nlohmann