### PR TITLE
Badges current branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,9 @@ env:
 jobs:
   coverage:
     name: Coverage
-    concurrency: gurobi
+    concurrency:
+      group: gurobi
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   coverage:
     name: Coverage
+    concurrency: gurobi
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   cpp-tests:
     name: Tests ${{ matrix.config.os }}
+    concurrency: gurobi
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,9 +24,11 @@ env:
   GUROBI_VERSION_FOLDER: "gurobi1002"
 
 jobs:
-  cpp-tests:
+  cpp-tests-macos:
     name: Tests ${{ matrix.config.os }}
-    concurrency: gurobi
+    concurrency:
+      group: gurobi
+      cancel-in-progress: false
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   cpp-tests:
     name: Tests ${{ matrix.config.os }}
+    concurrency: gurobi
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,9 +24,11 @@ env:
   GUROBI_VERSION_FOLDER: "gurobi1002"
 
 jobs:
-  cpp-tests:
+  cpp-tests-ubuntu:
     name: Tests ${{ matrix.config.os }}
-    concurrency: gurobi
+    concurrency:
+      group: gurobi
+      cancel-in-progress: false
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   cpp-tests:
     name: Tests ${{ matrix.config.os }}
+    concurrency: gurobi
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,9 +24,11 @@ env:
   GUROBI_VERSION_FOLDER: "gurobi1002"
 
 jobs:
-  cpp-tests:
+  cpp-tests-windows:
     name: Tests ${{ matrix.config.os }}
-    concurrency: gurobi
+    concurrency:
+      group: gurobi
+      cancel-in-progress: false
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false

--- a/.hooks/update_readme_links.py
+++ b/.hooks/update_readme_links.py
@@ -6,11 +6,11 @@ current_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "H
 print("Current branch:", current_branch)
 
 
-ubuntu = f"[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml)\n"
-macos = f"[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/macos.yml)\n"
-windows = f"[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/windows.yml)\n"
-codeql = f"[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml)\n"
-codecov = f"[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square?branch={current_branch})](https://codecov.io/gh/cda-tum/mtct)\n"
+ubuntu = f"[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml?query=branch%3A{current_branch})\n"
+macos = f"[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/macos.yml?query=branch%3A{current_branch})\n"
+windows = f"[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/windows.yml?query=branch%3A{current_branch})\n"
+codeql = f"[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml?query=branch%3A{current_branch})\n"
+codecov = f"[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square?branch={current_branch})](https://codecov.io/gh/cda-tum/mtct/tree/{current_branch})\n"
 
 
 lines = open("README.md").readlines()

--- a/.hooks/update_readme_links.py
+++ b/.hooks/update_readme_links.py
@@ -2,13 +2,13 @@
 
 import subprocess
 
-try:
-    current_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
-    print("Current branch:", current_branch)
-except Exception as e:
-    print("Error:", e)
+current_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
+print("Current branch:", current_branch)
 
 
-ubuntu = f"[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml)".format(current_branch=current_branch)
+ubuntu = f"[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml)\n"
 
 lines = open("README.md").readlines()
+for line in lines:
+    if ubuntu[:20] in line:
+        print(f"Replacing {line} with {ubuntu}")

--- a/.hooks/update_readme_links.py
+++ b/.hooks/update_readme_links.py
@@ -7,8 +7,29 @@ print("Current branch:", current_branch)
 
 
 ubuntu = f"[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml)\n"
+macos = f"[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/macos.yml)\n"
+windows = f"[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/windows.yml)\n"
+codeql = f"[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml)\n"
+codecov = f"[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square?branch={current_branch})](https://codecov.io/gh/cda-tum/mtct)\n"
+
 
 lines = open("README.md").readlines()
-for line in lines:
-    if ubuntu[:20] in line:
-        print(f"Replacing {line} with {ubuntu}")
+with open("README.md", "w") as f:
+    for line in lines:
+        if ubuntu[:20] in line:
+            print(f"Replacing {line} with {ubuntu}")
+            f.write(ubuntu)
+        elif macos[:20] in line:
+            print(f"Replacing {line} with {macos}")
+            f.write(macos)
+        elif windows[:20] in line:
+            print(f"Replacing {line} with {windows}")
+            f.write(windows)
+        elif codeql[:20] in line:
+            print(f"Replacing {line} with {codeql}")
+            f.write(codeql)
+        elif codecov[:20] in line:
+            print(f"Replacing {line} with {codecov}")
+            f.write(codecov)
+        else:
+            f.write(line)

--- a/.hooks/update_readme_links.py
+++ b/.hooks/update_readme_links.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import subprocess
+
+try:
+    current_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
+    print("Current branch:", current_branch)
+except Exception as e:
+    print("Error:", e)
+
+
+ubuntu = f"[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml)".format(current_branch=current_branch)
+
+lines = open("README.md").readlines()

--- a/.hooks/update_readme_links.py
+++ b/.hooks/update_readme_links.py
@@ -5,14 +5,12 @@ import subprocess
 current_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip().decode('utf-8')
 print("Current branch:", current_branch)
 
-
 ubuntu = f"[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml?query=branch%3A{current_branch})\n"
 macos = f"[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/macos.yml?query=branch%3A{current_branch})\n"
 windows = f"[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/windows.yml?query=branch%3A{current_branch})\n"
 codeql = f"[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml?query=branch%3A{current_branch})\n"
 codecov = f"[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square&branch={current_branch})](https://codecov.io/gh/cda-tum/mtct/tree/{current_branch})\n"
 lic = f"[![License](https://img.shields.io/github/license/cda-tum/mtct?label=License&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/blob/{current_branch}/LICENSE)\n"
-
 
 lines = open("README.md").readlines()
 with open("README.md", "w") as f:

--- a/.hooks/update_readme_links.py
+++ b/.hooks/update_readme_links.py
@@ -6,11 +6,12 @@ current_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "H
 print("Current branch:", current_branch)
 
 
-ubuntu = f"[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml?query=branch%3A{current_branch})\n"
-macos = f"[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/macos.yml?query=branch%3A{current_branch})\n"
-windows = f"[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/windows.yml?query=branch%3A{current_branch})\n"
-codeql = f"[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square?branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml?query=branch%3A{current_branch})\n"
-codecov = f"[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square?branch={current_branch})](https://codecov.io/gh/cda-tum/mtct/tree/{current_branch})\n"
+ubuntu = f"[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml?query=branch%3A{current_branch})\n"
+macos = f"[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/macos.yml?query=branch%3A{current_branch})\n"
+windows = f"[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/windows.yml?query=branch%3A{current_branch})\n"
+codeql = f"[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml?query=branch%3A{current_branch})\n"
+codecov = f"[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square&branch={current_branch})](https://codecov.io/gh/cda-tum/mtct/tree/{current_branch})\n"
+lic = f"[![License](https://img.shields.io/github/license/cda-tum/mtct?label=License&style=flat-square&branch={current_branch})](https://github.com/cda-tum/mtct/blob/{current_branch}/LICENSE)\n"
 
 
 lines = open("README.md").readlines()
@@ -31,5 +32,8 @@ with open("README.md", "w") as f:
         elif codecov[:20] in line and codecov not in line:
             print(f"Replacing {line} with {codecov}")
             f.write(codecov)
+        elif lic[:20] in line and lic not in line:
+            print(f"Replacing {line} with {lic}")
+            f.write(lic)
         else:
             f.write(line)

--- a/.hooks/update_readme_links.py
+++ b/.hooks/update_readme_links.py
@@ -16,19 +16,19 @@ codecov = f"[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?lab
 lines = open("README.md").readlines()
 with open("README.md", "w") as f:
     for line in lines:
-        if ubuntu[:20] in line:
+        if ubuntu[:20] in line and ubuntu not in line:
             print(f"Replacing {line} with {ubuntu}")
             f.write(ubuntu)
-        elif macos[:20] in line:
+        elif macos[:20] in line and macos not in line:
             print(f"Replacing {line} with {macos}")
             f.write(macos)
-        elif windows[:20] in line:
+        elif windows[:20] in line and windows not in line:
             print(f"Replacing {line} with {windows}")
             f.write(windows)
-        elif codeql[:20] in line:
+        elif codeql[:20] in line and codeql not in line:
             print(f"Replacing {line} with {codeql}")
             f.write(codeql)
-        elif codecov[:20] in line:
+        elif codecov[:20] in line and codecov not in line:
             print(f"Replacing {line} with {codecov}")
             f.write(codecov)
         else:

--- a/.hooks/update_readme_links.py
+++ b/.hooks/update_readme_links.py
@@ -2,7 +2,7 @@
 
 import subprocess
 
-current_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
+current_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip().decode('utf-8')
 print("Current branch:", current_branch)
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,6 @@ repos:
     hooks:
       - id: update-readme-links
         name: Update README.md Links
-        entry: |
-          sed -E -i "s|(/mtct/[^?]*\?label=[^&]*&logo=[^&]*&style=flat-square&branch=)([^&]*)|\1\$(git rev-parse --abbrev-ref HEAD)|g" README.md
-        language: system
+        entry: ./.hooks/update_readme_links.py
+        language: python
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,4 @@ repos:
         entry: ./.hooks/update_readme_links.py
         language: python
         pass_filenames: false
+        verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,15 @@ ci:
   autofix_commit_msg: "🎨 pre-commit fixes"
 
 repos:
+  - repo: local
+    hooks:
+      - id: update-readme-links
+        name: Update README.md Links
+        entry: ./.hooks/update_readme_links.py
+        language: python
+        pass_filenames: false
+        verbose: true
+
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.4.0"
@@ -56,12 +65,3 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
-
-  - repo: local
-    hooks:
-      - id: update-readme-links
-        name: Update README.md Links
-        entry: ./.hooks/update_readme_links.py
-        language: python
-        pass_filenames: false
-        verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,12 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
+
+  - repo: local
+    hooks:
+      - id: update-readme-links
+        name: Update README.md Links
+        entry: |
+          sed -E -i "s|(/mtct/[^?]*\?label=[^&]*&logo=[^&]*&style=flat-square&branch=)([^&]*)|\1\$(git rev-parse --abbrev-ref HEAD)|g" README.md
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml)
-[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/macos.yml)
-[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/windows.yml)
-[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml)
-[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square?branch=badges-current-branch)](https://codecov.io/gh/cda-tum/mtct)
+[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml?query=branch%3Abadges-current-branch)
+[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/macos.yml?query=branch%3Abadges-current-branch)
+[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/windows.yml?query=branch%3Abadges-current-branch)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml?query=branch%3Abadges-current-branch)
+[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square?branch=badges-current-branch)](https://codecov.io/gh/cda-tum/mtct/tree/badges-current-branch)
 [![License](https://img.shields.io/github/license/cda-tum/mtct?label=License&style=flat-square)](https://github.com/cda-tum/mtct/blob/main/LICENSE)
 
 # MTCT - Munich Train Control Toolkit

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square)](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml)
-[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square)](https://github.com/cda-tum/mtct/actions/workflows/macos.yml)
-[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square)](https://github.com/cda-tum/mtct/actions/workflows/windows.yml)
-[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square)](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml)
-[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square)](https://codecov.io/gh/cda-tum/mtct)
+[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml)
+[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/macos.yml)
+[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/windows.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml)
+[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square?branch=badges-current-branch)](https://codecov.io/gh/cda-tum/mtct)
 [![License](https://img.shields.io/github/license/cda-tum/mtct?label=License&style=flat-square)](https://github.com/cda-tum/mtct/blob/main/LICENSE)
 
 # MTCT - Munich Train Control Toolkit

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml?query=branch%3Abadges-current-branch)
-[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/macos.yml?query=branch%3Abadges-current-branch)
-[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/windows.yml?query=branch%3Abadges-current-branch)
-[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square?branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml?query=branch%3Abadges-current-branch)
-[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square?branch=badges-current-branch)](https://codecov.io/gh/cda-tum/mtct/tree/badges-current-branch)
-[![License](https://img.shields.io/github/license/cda-tum/mtct?label=License&style=flat-square)](https://github.com/cda-tum/mtct/blob/main/LICENSE)
+[![Ubuntu C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/ubuntu.yml?label=Ubuntu&logo=ubuntu&style=flat-square&branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/ubuntu.yml?query=branch%3Abadges-current-branch)
+[![macOS C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/macos.yml?label=macOS&logo=apple&style=flat-square&branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/macos.yml?query=branch%3Abadges-current-branch)
+[![Windows C++](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/windows.yml?label=Windows&logo=windows&style=flat-square&branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/windows.yml?query=branch%3Abadges-current-branch)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/cda-tum/mtct/codeql-analysis.yml?label=CodeQL&logo=github&style=flat-square&branch=badges-current-branch)](https://github.com/cda-tum/mtct/actions/workflows/codeql-analysis.yml?query=branch%3Abadges-current-branch)
+[![codecov](https://img.shields.io/codecov/c/github/cda-tum/mtct?label=Coverage&logo=codecov&style=flat-square&branch=badges-current-branch)](https://codecov.io/gh/cda-tum/mtct/tree/badges-current-branch)
+[![License](https://img.shields.io/github/license/cda-tum/mtct?label=License&style=flat-square&branch=badges-current-branch)](https://github.com/cda-tum/mtct/blob/badges-current-branch/LICENSE)
 
 # MTCT - Munich Train Control Toolkit
 


### PR DESCRIPTION
## Description

The badges are usually shown for the latest or main. This introduces pre-commit hooks so that the badges correspond to the branch they are displayed on.

Additionally this adds concurrency to jobs in order to prevent multiple jobs trying to use the WLS license at the same time, because if two WLS sessions are open at the same time any new job will fail due to missing license.

Fixes #35 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
