### PR TITLE
make CIs more consistent

### DIFF
--- a/.github/gurobi_version.json
+++ b/.github/gurobi_version.json
@@ -1,0 +1,1 @@
+{"gurobiShortVersion": "10.0", "gurobiVersion": "10.0.3", "gurobiFolder": "gurobi1003"}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,9 @@ concurrency:
 
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 3
+  GUROBI_VERSION_SHORT: "10.0"
+  GUROBI_VERSION: "10.0.3"
+  GUROBI_VERSION_FOLDER: "gurobi1003"
 
 jobs:
   analyze:
@@ -34,10 +37,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: download-gurobi-linux
-        shell: bash
+        env:
+          GUROBI_FILE: gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz
         run: |
-          wget https://packages.gurobi.com/10.0/gurobi10.0.2_linux64.tar.gz
-          tar -xvzf gurobi10.0.2_linux64.tar.gz
+          wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}
+          tar -xvzf ${{ env.GUROBI_FILE }}
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,6 @@ concurrency:
 
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 3
-  GUROBI_VERSION_SHORT: "10.0"
-  GUROBI_VERSION: "10.0.3"
-  GUROBI_VERSION_FOLDER: "gurobi1003"
 
 jobs:
   analyze:
@@ -36,10 +33,16 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Read current gurobi Version
+        uses: zlatko-ms/varfiletoenv@v3
+        with:
+          paths: ./.github/gurobi_version.json
       - name: download-gurobi-linux
-        shell: bash
         env:
-          GUROBI_FILE: gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz
+          GUROBI_VERSION_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERSION: ${{ env.gurobiVersion }}
+          GUROBI_VERSION_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_FILE: gurobi${{ env.gurobiVersion }}_linux64.tar.gz
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}
           tar -xvzf ${{ env.GUROBI_FILE }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       - name: download-gurobi-linux
+        shell: bash
         env:
           GUROBI_FILE: gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz
         run: |

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -149,8 +149,8 @@ jobs:
         id: gurobi-env-variables
         shell: powershell
         run: |
-          echo "GUROBI_HOME=$PWD\gurobi\$env:GUROBI_VERSION_FOLDER\win64" >> $env:GITHUB_ENV
-          echo "$PWD\gurobi\$env:GUROBI_VERSION_FOLDER\win64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "GUROBI_HOME=$PWD\gurobi\$env:gurobiFolder\win64" >> $env:GITHUB_ENV
+          echo "$PWD\gurobi\$env:gurobiFolder\win64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON ${{ matrix.config.toolchain }}
       - name: Build

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -54,6 +54,14 @@ jobs:
         run: cmake --build build --config Release
       - name: Test
         run: ctest -C Release --output-on-failure --test-dir build --repeat until-pass:3 --timeout 400
+      - name: Export variables for next jobs
+        uses: UnlyEd/github-action-store-variable@v3 # See https://github.com/UnlyEd/github-action-store-variable
+        with:
+          # Persist (store) our MAGIC_NUMBER ENV variable into our store, for the next jobs
+          variables: |
+            gurobiVersion=${{ env.gurobiVersion }}
+            gurobiShortVersion=${{ env.gurobiShortVersion }}
+            gurobiFolder=${{ env.gurobiFolder }}
   cpp-macos-latest:
     name: cpp-macos-latest
     runs-on: macos-latest
@@ -69,10 +77,15 @@ jobs:
         run: |
           echo "$GUROBI_LICENSE" > $PWD/gurobi.lic
           echo "GRB_LICENSE_FILE=$PWD/gurobi.lic" >> $GITHUB_ENV
-      - name: Read current gurobi Version
-        uses: zlatko-ms/varfiletoenv@v3
+      - name: Import variables
+        uses: UnlyEd/github-action-store-variable@v3 # See https://github.com/UnlyEd/github-action-store-variable
         with:
-          paths: ./.github/gurobi_version.json
+          # List all variables you want to retrieve from the store
+          # XXX They'll be automatically added to your ENV
+          variables: |
+            gurobiVersion
+            gurobiShortVersion
+            gurobiFolder
       - name: download-gurobi-mac
         env:
           GUROBI_VERSION_SHORT: ${{ env.gurobiShortVersion }}
@@ -103,10 +116,15 @@ jobs:
         run: |
           echo "$GUROBI_LICENSE" > $PWD/gurobi.lic
           echo "GRB_LICENSE_FILE=$PWD/gurobi.lic" >> $GITHUB_ENV
-      - name: Read current gurobi Version
-        uses: zlatko-ms/varfiletoenv@v3
+      - name: Import variables
+        uses: UnlyEd/github-action-store-variable@v3 # See https://github.com/UnlyEd/github-action-store-variable
         with:
-          paths: ./.github/gurobi_version.json
+          # List all variables you want to retrieve from the store
+          # XXX They'll be automatically added to your ENV
+          variables: |
+            gurobiVersion
+            gurobiShortVersion
+            gurobiFolder
       - name: download-gurobi-windows
         shell: powershell
         env:
@@ -154,10 +172,15 @@ jobs:
         run: |
           echo "$GUROBI_LICENSE" > $PWD/gurobi.lic
           echo "GRB_LICENSE_FILE=$PWD/gurobi.lic" >> $GITHUB_ENV
-      - name: Read current gurobi Version
-        uses: zlatko-ms/varfiletoenv@v3
+      - name: Import variables
+        uses: UnlyEd/github-action-store-variable@v3 # See https://github.com/UnlyEd/github-action-store-variable
         with:
-          paths: ./.github/gurobi_version.json
+          # List all variables you want to retrieve from the store
+          # XXX They'll be automatically added to your ENV
+          variables: |
+            gurobiVersion
+            gurobiShortVersion
+            gurobiFolder
       - name: download-gurobi-linux
         env:
           GUROBI_VERSION_SHORT: ${{ env.gurobiShortVersion }}

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -19,9 +19,6 @@ defaults:
 env:
   CMAKE_BUILD_PARALLEL_LEVEL: 3
   CTEST_PARALLEL_LEVEL: 1
-  GUROBI_VERSION_SHORT: "10.0"
-  GUROBI_VERSION: "10.0.3"
-  GUROBI_VERSION_FOLDER: "gurobi1003"
 
 jobs:
   cpp-ubuntu-latest:
@@ -38,9 +35,16 @@ jobs:
         run: |
           echo "$GUROBI_LICENSE" > $PWD/gurobi.lic
           echo "GRB_LICENSE_FILE=$PWD/gurobi.lic" >> $GITHUB_ENV
+      - name: Read current gurobi Version
+        uses: zlatko-ms/varfiletoenv@v3
+        with:
+          paths: ./.github/gurobi_version.json
       - name: download-gurobi-linux
         env:
-          GUROBI_FILE: gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz
+          GUROBI_VERISON_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERISON: ${{ env.gurobiVersion }}
+          GUROBI_VERISON_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_FILE: gurobi${{ env.gurobiVersion }}_linux64.tar.gz
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}
           tar -xvzf ${{ env.GUROBI_FILE }}
@@ -65,9 +69,16 @@ jobs:
         run: |
           echo "$GUROBI_LICENSE" > $PWD/gurobi.lic
           echo "GRB_LICENSE_FILE=$PWD/gurobi.lic" >> $GITHUB_ENV
+      - name: Read current gurobi Version
+        uses: zlatko-ms/varfiletoenv@v3
+        with:
+          paths: ./.github/gurobi_version.json
       - name: download-gurobi-mac
         env:
-          GUROBI_FILE: gurobi${{ env.GUROBI_VERSION }}_macos_universal2.pkg
+          GUROBI_VERISON_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERISON: ${{ env.gurobiVersion }}
+          GUROBI_VERISON_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_FILE: gurobi${{ env.gurobiVersion }}_macos_universal2.pkg
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}
           sudo installer -pkg ${{ env.GUROBI_FILE }} -target /
@@ -92,10 +103,17 @@ jobs:
         run: |
           echo "$GUROBI_LICENSE" > $PWD/gurobi.lic
           echo "GRB_LICENSE_FILE=$PWD/gurobi.lic" >> $GITHUB_ENV
+      - name: Read current gurobi Version
+        uses: zlatko-ms/varfiletoenv@v3
+        with:
+          paths: ./.github/gurobi_version.json
       - name: download-gurobi-windows
         shell: powershell
         env:
-          GUROBI_FILE: Gurobi-${{ env.GUROBI_VERSION }}-win64.msi
+          GUROBI_VERISON_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERISON: ${{ env.gurobiVersion }}
+          GUROBI_VERISON_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_FILE: Gurobi-${{ env.gurobiVersion }}-win64.msi
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }} -OutFile ${{ env.GUROBI_FILE }}
           New-Item -itemType directory gurobi
@@ -136,9 +154,16 @@ jobs:
         run: |
           echo "$GUROBI_LICENSE" > $PWD/gurobi.lic
           echo "GRB_LICENSE_FILE=$PWD/gurobi.lic" >> $GITHUB_ENV
+      - name: Read current gurobi Version
+        uses: zlatko-ms/varfiletoenv@v3
+        with:
+          paths: ./.github/gurobi_version.json
       - name: download-gurobi-linux
         env:
-          GUROBI_FILE: gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz
+          GUROBI_VERISON_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERISON: ${{ env.gurobiVersion }}
+          GUROBI_VERISON_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_FILE: gurobi${{ env.gurobiVersion }}_linux64.tar.gz
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}
           tar -xvzf ${{ env.GUROBI_FILE }}

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -41,9 +41,9 @@ jobs:
           paths: ./.github/gurobi_version.json
       - name: download-gurobi-linux
         env:
-          GUROBI_VERISON_SHORT: ${{ env.gurobiShortVersion }}
-          GUROBI_VERISON: ${{ env.gurobiVersion }}
-          GUROBI_VERISON_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_VERSION_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERSION: ${{ env.gurobiVersion }}
+          GUROBI_VERSION_FOLDER: ${{ env.gurobiFolder }}
           GUROBI_FILE: gurobi${{ env.gurobiVersion }}_linux64.tar.gz
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}
@@ -75,9 +75,9 @@ jobs:
           paths: ./.github/gurobi_version.json
       - name: download-gurobi-mac
         env:
-          GUROBI_VERISON_SHORT: ${{ env.gurobiShortVersion }}
-          GUROBI_VERISON: ${{ env.gurobiVersion }}
-          GUROBI_VERISON_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_VERSION_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERSION: ${{ env.gurobiVersion }}
+          GUROBI_VERSION_FOLDER: ${{ env.gurobiFolder }}
           GUROBI_FILE: gurobi${{ env.gurobiVersion }}_macos_universal2.pkg
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}
@@ -110,9 +110,9 @@ jobs:
       - name: download-gurobi-windows
         shell: powershell
         env:
-          GUROBI_VERISON_SHORT: ${{ env.gurobiShortVersion }}
-          GUROBI_VERISON: ${{ env.gurobiVersion }}
-          GUROBI_VERISON_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_VERSION_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERSION: ${{ env.gurobiVersion }}
+          GUROBI_VERSION_FOLDER: ${{ env.gurobiFolder }}
           GUROBI_FILE: Gurobi-${{ env.gurobiVersion }}-win64.msi
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }} -OutFile ${{ env.GUROBI_FILE }}
@@ -160,9 +160,9 @@ jobs:
           paths: ./.github/gurobi_version.json
       - name: download-gurobi-linux
         env:
-          GUROBI_VERISON_SHORT: ${{ env.gurobiShortVersion }}
-          GUROBI_VERISON: ${{ env.gurobiVersion }}
-          GUROBI_VERISON_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_VERSION_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERSION: ${{ env.gurobiVersion }}
+          GUROBI_VERSION_FOLDER: ${{ env.gurobiFolder }}
           GUROBI_FILE: gurobi${{ env.gurobiVersion }}_linux64.tar.gz
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           submodules: recursive
       - name: download-gurobi-linux
+        shell: bash
         env:
           GUROBI_FILE: gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz
         run: |

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -12,6 +12,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  GUROBI_VERSION_SHORT: "10.0"
+  GUROBI_VERSION: "10.0.3"
+  GUROBI_VERSION_FOLDER: "gurobi1003"
+
 jobs:
   cpp-linter:
     runs-on: ubuntu-latest
@@ -20,10 +25,11 @@ jobs:
         with:
           submodules: recursive
       - name: download-gurobi-linux
-        shell: bash
+        env:
+          GUROBI_FILE: gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz
         run: |
-          wget https://packages.gurobi.com/10.0/gurobi10.0.2_linux64.tar.gz
-          tar -xvzf gurobi10.0.2_linux64.tar.gz
+          wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}
+          tar -xvzf ${{ env.GUROBI_FILE }}
       - name: Generate compilation database
         run: |
           CC=clang-14 CXX=clang++-14 \

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -12,11 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  GUROBI_VERSION_SHORT: "10.0"
-  GUROBI_VERSION: "10.0.3"
-  GUROBI_VERSION_FOLDER: "gurobi1003"
-
 jobs:
   cpp-linter:
     runs-on: ubuntu-latest
@@ -24,10 +19,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Read current gurobi Version
+        uses: zlatko-ms/varfiletoenv@v3
+        with:
+          paths: ./.github/gurobi_version.json
       - name: download-gurobi-linux
-        shell: bash
         env:
-          GUROBI_FILE: gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz
+          GUROBI_VERSION_SHORT: ${{ env.gurobiShortVersion }}
+          GUROBI_VERSION: ${{ env.gurobiVersion }}
+          GUROBI_VERSION_FOLDER: ${{ env.gurobiFolder }}
+          GUROBI_FILE: gurobi${{ env.gurobiVersion }}_linux64.tar.gz
         run: |
           wget https://packages.gurobi.com/${{ env.GUROBI_VERSION_SHORT }}/${{ env.GUROBI_FILE }}
           tar -xvzf ${{ env.GUROBI_FILE }}


### PR DESCRIPTION
## Description

The goal of this PR is to have the Gurobi Version stored only in one location instead of three .yml files so that the CIs are more consistent with each other. Especially, if one forgets to update only one place if a new Gurobi version is released.

Also this enables the possibility of a custom dependabot-like CI that checks for new Gurobi versions and updates the json if applicable. I think I have a running prototype for this in a private repo, which I might add as a PR to this repo in the future. However, for this, the changes from this PR should already be merged into main.

Fixes # (issue)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
