### PR TITLE
Update dependabot.yml to add reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "friday"
       time: "06:00"
       timezone: "Europe/Vienna"
+    reviewers:
+      - "sengels-tum"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,6 +17,8 @@ updates:
       day: "friday"
       time: "06:00"
       timezone: "Europe/Vienna"
+    reviewers:
+      - "sengels-tum"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -23,3 +27,5 @@ updates:
       day: "friday"
       time: "06:00"
       timezone: "Europe/Vienna"
+    reviewers:
+      - "sengels-tum"


### PR DESCRIPTION
## Description

This add reviewers to dependabot. This way I (as a reviewer) get emails from GitHub whenever something is updated.

Fixes # (issue)

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
