### PR TITLE
Add overlap detection, track index and position query helper functions

### DIFF
--- a/include/datastructure/RailwayNetwork.hpp
+++ b/include/datastructure/RailwayNetwork.hpp
@@ -505,6 +505,7 @@ public:
     return edge_index.has_value() ? get_reverse_edge_index(edge_index.value())
                                   : std::optional<size_t>();
   }
+  [[nodiscard]] size_t                get_track_index(size_t edge_index) const;
   [[nodiscard]] std::optional<size_t> common_vertex(
       const std::pair<std::optional<size_t>, std::optional<size_t>>& pair1,
       const std::pair<std::optional<size_t>, std::optional<size_t>>& pair2)

--- a/include/datastructure/Route.hpp
+++ b/include/datastructure/Route.hpp
@@ -85,12 +85,12 @@ public:
   [[nodiscard]] bool check_consistency(const Network& network) const;
 
   [[nodiscard]] std::optional<double>
-  get_first_pos_on_edges(const std::vector<size_t>& edge_indices,
-                         const Network&             network) const;
+  get_first_pos_on_edges(const cda_rail::index_vector& edge_indices,
+                         const Network&                network) const;
 
   [[nodiscard]] std::optional<double>
-  get_last_pos_on_edges(const std::vector<size_t>& edge_indices,
-                        const Network&             network) const;
+  get_last_pos_on_edges(const cda_rail::index_vector& edge_indices,
+                        const Network&                network) const;
 
   void update_after_discretization(
       const std::vector<std::pair<size_t, cda_rail::index_vector>>& new_edges);

--- a/include/datastructure/Route.hpp
+++ b/include/datastructure/Route.hpp
@@ -8,7 +8,6 @@
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/include/datastructure/Route.hpp
+++ b/include/datastructure/Route.hpp
@@ -16,9 +16,11 @@
 
 namespace cda_rail {
 
-using ConflictPair =
-    std::tuple<std::pair<double, double>, std::pair<double, double>,
-               std::unordered_set<size_t>>;
+struct ConflictPair {
+  std::pair<double, double>  pos1;
+  std::pair<double, double>  pos2;
+  std::unordered_set<size_t> edges;
+};
 
 class Route {
 private:

--- a/include/datastructure/Route.hpp
+++ b/include/datastructure/Route.hpp
@@ -8,11 +8,18 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
 namespace cda_rail {
+
+using ConflictPair =
+    std::tuple<std::pair<double, double>, std::pair<double, double>,
+               std::unordered_set<size_t>>;
+
 class Route {
 private:
   cda_rail::index_vector edges;
@@ -76,6 +83,14 @@ public:
   }
 
   [[nodiscard]] bool check_consistency(const Network& network) const;
+
+  [[nodiscard]] std::optional<double>
+  get_first_pos_on_edges(const std::vector<size_t>& edge_indices,
+                         const Network&             network) const;
+
+  [[nodiscard]] std::optional<double>
+  get_last_pos_on_edges(const std::vector<size_t>& edge_indices,
+                        const Network&             network) const;
 
   void update_after_discretization(
       const std::vector<std::pair<size_t, cda_rail::index_vector>>& new_edges);
@@ -157,6 +172,20 @@ public:
            const Network& network) const {
     return get_route(train_name).edge_pos(edges, network);
   };
+
+  // Overlap functions
+  [[nodiscard]] std::vector<ConflictPair>
+  get_parallel_overlaps(const std::string& train1, const std::string& train2,
+                        const Network& network) const;
+  [[nodiscard]] std::vector<ConflictPair>
+  get_ttd_overlaps(const std::string& train1, const std::string& train2,
+                   const Network& network) const;
+  [[nodiscard]] std::vector<ConflictPair>
+  get_reverse_overlaps(const std::string& train1, const std::string& train2,
+                       const Network& network) const;
+  [[nodiscard]] std::vector<ConflictPair>
+  get_crossing_overlaps(const std::string& train1, const std::string& train2,
+                        const Network& network) const;
 
   [[nodiscard]] bool
   check_consistency(const TrainList& trains, const Network& network,

--- a/include/datastructure/Train.hpp
+++ b/include/datastructure/Train.hpp
@@ -65,6 +65,7 @@ public:
 
   size_t add_train(const std::string& name, int length, double max_speed,
                    double acceleration, double deceleration, bool tim = true);
+  size_t add_train(const Train& train);
   [[nodiscard]] size_t size() const { return trains.size(); };
 
   [[nodiscard]] size_t       get_train_index(const std::string& name) const;

--- a/include/probleminstances/GeneralProblemInstance.hpp
+++ b/include/probleminstances/GeneralProblemInstance.hpp
@@ -15,6 +15,7 @@
 #include <filesystem>
 #include <fstream>
 #include <numeric>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -166,6 +167,44 @@ public:
                   const cda_rail::index_vector& edges_to_consider = {}) const {
     return timetable.get_stop_tracks(tr, station_name, this->const_n(),
                                      edges_to_consider);
+  };
+
+  [[nodiscard]] std::optional<double>
+  get_last_stop_position_on_route(size_t             tr_id,
+                                  const std::string& station_name) const {
+    const auto& tr_obj      = get_train_list().get_train(tr_id);
+    const auto& route       = get_route(tr_obj.name);
+    const auto& route_edges = route.get_edges();
+    const auto  stop_tracks_tmp =
+        get_stop_tracks(tr_id, station_name, route_edges);
+    cda_rail::index_vector stop_tracks;
+    for (const auto& [idx, paths] : stop_tracks_tmp) {
+      for (const auto& path : paths) {
+        stop_tracks.insert(stop_tracks.end(), path.begin(), path.end());
+      }
+    }
+    return route.get_last_pos_on_edges(stop_tracks, this->const_n());
+  };
+
+  // Overlap functions
+  [[nodiscard]] std::vector<ConflictPair>
+  get_parallel_overlaps(const std::string& train1,
+                        const std::string& train2) const {
+    return get_routes().get_parallel_overlaps(train1, train2, this->const_n());
+  };
+  [[nodiscard]] std::vector<ConflictPair>
+  get_ttd_overlaps(const std::string& train1, const std::string& train2) const {
+    return get_routes().get_ttd_overlaps(train1, train2, this->const_n());
+  };
+  [[nodiscard]] std::vector<ConflictPair>
+  get_reverse_overlaps(const std::string& train1,
+                       const std::string& train2) const {
+    return get_routes().get_reverse_overlaps(train1, train2, this->const_n());
+  };
+  [[nodiscard]] std::vector<ConflictPair>
+  get_crossing_overlaps(const std::string& train1,
+                        const std::string& train2) const {
+    return get_routes().get_crossing_overlaps(train1, train2, this->const_n());
   };
 
   [[nodiscard]] std::vector<

--- a/src/datastructure/RailwayNetwork.cpp
+++ b/src/datastructure/RailwayNetwork.cpp
@@ -1423,6 +1423,14 @@ cda_rail::Network::get_reverse_edge_index(size_t edge_index) const {
   return {};
 }
 
+size_t cda_rail::Network::get_track_index(size_t edge_index) const {
+  const auto reverse_edge_index = get_reverse_edge_index(edge_index);
+  if (reverse_edge_index.has_value()) {
+    return std::min(edge_index, reverse_edge_index.value());
+  }
+  return edge_index;
+}
+
 cda_rail::index_vector
 cda_rail::Network::get_vertices_by_type(VertexType type) const {
   /**

--- a/src/datastructure/Route.cpp
+++ b/src/datastructure/Route.cpp
@@ -826,10 +826,12 @@ cda_rail::RouteMap::get_reverse_overlaps(const std::string& train1,
 
       // Extend the overlap as long as edges match
       bool i2_at_end = false;
-      while (!i2_at_end && i1 < edges1.size() &&
-             network.get_reverse_edge_index(edges1.at(i1)).has_value() &&
-             network.get_reverse_edge_index(edges1.at(i1)).value_or(-1) ==
-                 edges2.at(i2)) {
+
+      while (!i2_at_end && i1 < edges1.size()) {
+        if (const auto rev = network.get_reverse_edge_index(edges1.at(i1));
+            !rev.has_value() || rev.value() != edges2.at(i2)) {
+          break;
+        }
         assert(network.get_track_index(edges1.at(i1)) ==
                network.get_track_index(edges2.at(i2)));
         edges_in_overlap.insert(network.get_track_index(edges1.at(i1)));

--- a/src/datastructure/Route.cpp
+++ b/src/datastructure/Route.cpp
@@ -8,11 +8,16 @@
 #include "nlohmann/json_fwd.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <numeric>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -584,4 +589,318 @@ void cda_rail::RouteMap::remove_route(const std::string& train_name) {
     throw exceptions::ConsistencyException("Train does not have a route.");
   }
   routes.erase(train_name);
+}
+
+std::optional<double>
+cda_rail::Route::get_first_pos_on_edges(const std::vector<size_t>& edge_indices,
+                                        const Network& network) const {
+  /**
+   * This functions returns the position at the beginning of the first route
+   * edge that is part of edge_indices.
+   *
+   * @param edge_indices The edge indices to consider.
+   * @param network The network to which the route belongs.
+   * @return The position at the beginning of the first route edge that is part
+   * of edge_indices
+   */
+
+  double position = 0.0;
+  for (const auto& edge : edges) {
+    if (std::ranges::contains(edge_indices, edge)) {
+      return position;
+    }
+    position += network.get_edge(edge).length;
+  }
+  return {};
+}
+
+std::optional<double>
+cda_rail::Route::get_last_pos_on_edges(const std::vector<size_t>& edge_indices,
+                                       const Network& network) const {
+  /**
+   * This functions returns the position at the end of the last route edge that
+   * is part of edge_indices.
+   *
+   * @param edge_indices The edge indices to consider.
+   * @param network The network to which the route belongs.
+   * @return The position at the end of the last route edge that is part of
+   * edge_indices.
+   */
+
+  double                position = 0.0;
+  std::optional<double> return_position;
+  for (const auto& edge : edges) {
+    position += network.get_edge(edge).length;
+    if (std::ranges::contains(edge_indices, edge)) {
+      return_position = position;
+    }
+  }
+  return return_position;
+}
+
+std::vector<cda_rail::ConflictPair>
+cda_rail::RouteMap::get_parallel_overlaps(const std::string& train1,
+                                          const std::string& train2,
+                                          const Network&     network) const {
+  /**
+   * This functions returns all parallel overlaps between the routes of train1
+   * and train2. An overlap is an interval in which both trains are on the same
+   * tracks. The return information returns the start and end positions of the
+   * overlap ob both routes (in m). E.g., if train1 travels on e1, e2, e3, e4
+   * and train2 travels on e0, e2, e3, e5; then the overlap is on e2 and e3,
+   * i.e., the return value is {(length(e1), length(e1)+length(e2)+length(e3)),
+   * (length(e0), length(e0)+length(e2)+length(e3))}.
+   *
+   * @param train1 The name of the first train.
+   * @param train2 The name of the second train.
+   * @param network The network to which the routes belong.
+   * @return A vector of ConflictPairs representing the overlaps.
+   */
+
+  std::vector<ConflictPair> result;
+
+  // Get both routes
+  const auto& route1 = get_route(train1);
+  const auto& route2 = get_route(train2);
+
+  const auto& edges1 = route1.get_edges();
+  const auto& edges2 = route2.get_edges();
+
+  if (edges1.empty() || edges2.empty()) {
+    return result;
+  }
+
+  // Find all consecutive overlaps
+  size_t i1   = 0;
+  double pos1 = 0.0;
+  while (i1 < edges1.size()) {
+    // Check if current edge in route1 exists in route2
+    const size_t edge1 = edges1.at(i1);
+    if (const auto edge2_index = std::ranges::find(edges2, edge1);
+        edge2_index != edges2.end()) {
+      // Found an overlapping edge, now find the full overlap
+      size_t i2 = std::distance(edges2.begin(), edge2_index);
+      std::unordered_set<size_t> edges_in_overlap;
+
+      assert(i1 < edges1.size() && i2 < edges2.size() &&
+             edges1.at(i1) == edges2.at(i2));
+
+      // Calculate start position
+      double       pos2       = route2.edge_pos(edge1, network).first;
+      const double start_pos1 = pos1;
+      const double start_pos2 = pos2;
+
+      // Extend the overlap as long as edges match
+      while (i1 < edges1.size() && i2 < edges2.size() &&
+             edges1.at(i1) == edges2.at(i2)) {
+        edges_in_overlap.insert(network.get_track_index(edges1.at(i1)));
+        pos1 += network.get_edge(edges1.at(i1)).length;
+        pos2 += network.get_edge(edges2.at(i2)).length;
+        ++i1;
+        ++i2;
+      }
+
+      // Store the found overlap
+      result.emplace_back(std::make_pair(start_pos1, pos1),
+                          std::make_pair(start_pos2, pos2), edges_in_overlap);
+    } else {
+      // No overlap, move to the next edge in route1
+      pos1 += network.get_edge(edge1).length;
+      ++i1;
+    }
+  }
+
+  return result;
+}
+
+std::vector<cda_rail::ConflictPair>
+cda_rail::RouteMap::get_ttd_overlaps(const std::string& train1,
+                                     const std::string& train2,
+                                     const Network&     network) const {
+  /**
+   * This functions returns all ttd overlaps between the routes of train1
+   * and train2. An overlap is an interval in which both trains are on the same
+   * TTD section. The return information returns the start and end positions of
+   * the overlap ob both routes (in m), similarly to parallel overlaps.
+   *
+   * @param train1 The name of the first train.
+   * @param train2 The name of the second train.
+   * @param network The network to which the routes belong.
+   * @return A vector of ConflictPairs representing the overlaps.
+   */
+
+  std::vector<ConflictPair> result;
+
+  // Get both routes
+  const auto& route1 = get_route(train1);
+  const auto& route2 = get_route(train2);
+  const auto& edges1 = route1.get_edges();
+  const auto& edges2 = route2.get_edges();
+
+  std::unordered_set<size_t> blacklist;
+  for (const auto& edge1 : edges1) {
+    if (blacklist.contains(edge1)) {
+      continue;
+    }
+
+    if (const auto& e1_obj = network.get_edge(edge1); e1_obj.breakable) {
+      continue;
+    }
+    const auto& ttd_sec =
+        network.get_unbreakable_section_containing_edge(edge1);
+    assert(!ttd_sec.empty());
+    std::unordered_set<size_t> ttd_tracks;
+    for (const auto& ttd_sec_edge : ttd_sec) {
+      ttd_tracks.insert(network.get_track_index(ttd_sec_edge));
+      blacklist.insert(ttd_sec_edge);
+    }
+    const auto start_pos2 = route2.get_first_pos_on_edges(ttd_sec, network);
+    const auto end_pos2   = route2.get_last_pos_on_edges(ttd_sec, network);
+    assert(start_pos2.has_value() == end_pos2.has_value());
+    if (start_pos2.has_value() && end_pos2.has_value()) {
+      const auto start_pos1 = route1.get_first_pos_on_edges(ttd_sec, network);
+      const auto end_pos1   = route1.get_last_pos_on_edges(ttd_sec, network);
+      assert(start_pos1.has_value() && end_pos1.has_value());
+      result.emplace_back(std::make_pair(start_pos1.value(), end_pos1.value()),
+                          std::make_pair(start_pos2.value(), end_pos2.value()),
+                          ttd_tracks);
+    }
+  }
+
+  return result;
+}
+
+std::vector<cda_rail::ConflictPair>
+cda_rail::RouteMap::get_reverse_overlaps(const std::string& train1,
+                                         const std::string& train2,
+                                         const Network&     network) const {
+  /**
+   * This functions returns all reverse overlaps between the routes of train1
+   * and train2, i.e., parts where both trains travel on the same track but in
+   * different direction. The return information returns the start and end
+   * positions of the overlap ob both routes (in m). E.g., if train1 travels on
+   * e1, e2, e3, e4 and train2 travels on e5, e3', e2', e0; (e3' and e2' being
+   * the reverse indices of e3 and r2), then the overlap is on e2 and e3, i.e.,
+   * the return value is {(length(e1), length(e1)+length(e2)+length(e3)),
+   * (length(e5), length(e5)+length(e2')+length(e3'))}.
+   *
+   * @param train1 The name of the first train.
+   * @param train2 The name of the second train.
+   * @param network The network to which the routes belong.
+   * @return A vector of ConflictPairs representing the overlaps.
+   */
+
+  std::vector<ConflictPair> result;
+
+  // Get both routes
+  const auto& route1 = get_route(train1);
+  const auto& route2 = get_route(train2);
+
+  const auto& edges1 = route1.get_edges();
+  const auto& edges2 = route2.get_edges();
+
+  if (edges1.empty() || edges2.empty()) {
+    return result;
+  }
+
+  // Find all consecutive overlaps
+  size_t i1   = 0;
+  double pos1 = 0.0;
+  while (i1 < edges1.size()) {
+    // Check if current edge in route1 exists in route2
+    const size_t edge1 = edges1.at(i1);
+    if (const auto edge1_reverse = network.get_reverse_edge_index(edge1);
+        (edge1_reverse.has_value() &&
+         std::ranges::contains(edges2, edge1_reverse.value()))) {
+      const auto edge2_index = std::ranges::find(edges2, edge1_reverse.value());
+      // Found an overlapping edge, now find the full overlap
+      size_t i2 = std::distance(edges2.begin(), edge2_index);
+      std::unordered_set<size_t> edges_in_overlap;
+
+      assert(i1 < edges1.size() && i2 < edges2.size() &&
+             edges2.at(i2) == edge1_reverse.value());
+
+      // Calculate start position
+      double pos2 = route2.edge_pos(edge1_reverse.value(), network).second;
+      const double start_pos1 = pos1;
+      const double end_pos2   = pos2;
+
+      // Extend the overlap as long as edges match
+      bool i2_at_end = false;
+      while (!i2_at_end && i1 < edges1.size() &&
+             network.get_reverse_edge_index(edges1.at(i1)).has_value() &&
+             network.get_reverse_edge_index(edges1.at(i1)).value_or(-1) ==
+                 edges2.at(i2)) {
+        assert(network.get_track_index(edges1.at(i1)) ==
+               network.get_track_index(edges2.at(i2)));
+        edges_in_overlap.insert(network.get_track_index(edges1.at(i1)));
+        pos1 += network.get_edge(edges1.at(i1)).length;
+        pos2 -= network.get_edge(edges2.at(i2)).length;
+        ++i1;
+        i2_at_end = (i2 == 0);
+        if (!i2_at_end) {
+          --i2;
+        }
+      }
+
+      // Store the found overlap
+      result.emplace_back(std::make_pair(start_pos1, pos1),
+                          std::make_pair(pos2, end_pos2), edges_in_overlap);
+    } else {
+      // No overlap, move to the next edge in route1
+      pos1 += network.get_edge(edge1).length;
+      ++i1;
+    }
+  }
+
+  return result;
+}
+
+std::vector<cda_rail::ConflictPair>
+cda_rail::RouteMap::get_crossing_overlaps(const std::string& train1,
+                                          const std::string& train2,
+                                          const Network&     network) const {
+  /**
+   * combine ttd and reverse conflicts
+   */
+  const auto ttd_conflicts     = get_ttd_overlaps(train1, train2, network);
+  const auto reverse_conflicts = get_reverse_overlaps(train1, train2, network);
+
+  // concatenate conflicts and order by train 1 start
+  std::vector<ConflictPair> conflicts;
+  conflicts.reserve(ttd_conflicts.size() + reverse_conflicts.size());
+  conflicts.insert(conflicts.end(), ttd_conflicts.begin(), ttd_conflicts.end());
+  conflicts.insert(conflicts.end(), reverse_conflicts.begin(),
+                   reverse_conflicts.end());
+  std::ranges::sort(conflicts,
+                    [](const ConflictPair& a, const ConflictPair& b) {
+                      const auto& [a1, a2, a3] = a;
+                      const auto& [b1, b2, b3] = b;
+                      return a1.first < b1.first;
+                    });
+
+  // for any two conflicts, unite them if they are directly next to each other
+  // or overlap, i.e., if train1_end of prev >= train1_start of succ AND if
+  // train2_end of succ >= train_2 start of prev Then unite them into one
+  // conflict
+  std::vector<ConflictPair> result;
+  if (conflicts.empty()) {
+    return result;
+  }
+
+  result.emplace_back(conflicts.at(0));
+  for (size_t i = 1; i < conflicts.size(); ++i) {
+    auto& [prev1, prev2, prev_edges] = result.back();
+
+    if (const auto& [succ1, succ2, succ_edges] = conflicts.at(i);
+        prev1.second >= succ1.first && succ2.second >= prev2.first) {
+      prev1.second = std::max(prev1.second, succ1.second);
+      prev2.first  = std::min(prev2.first, succ2.first);
+      prev_edges.insert(succ_edges.begin(), succ_edges.end());
+    } else {
+      result.emplace_back(conflicts.at(i));
+    }
+  }
+
+  return result;
 }

--- a/src/datastructure/Route.cpp
+++ b/src/datastructure/Route.cpp
@@ -735,7 +735,6 @@ cda_rail::RouteMap::get_ttd_overlaps(const std::string& train1,
   const auto& route1 = get_route(train1);
   const auto& route2 = get_route(train2);
   const auto& edges1 = route1.get_edges();
-  const auto& edges2 = route2.get_edges();
 
   std::unordered_set<size_t> blacklist;
   for (const auto& edge1 : edges1) {

--- a/src/datastructure/Route.cpp
+++ b/src/datastructure/Route.cpp
@@ -895,6 +895,7 @@ cda_rail::RouteMap::get_crossing_overlaps(const std::string& train1,
     const auto& succ = conflicts.at(i);
 
     if (prev.pos1.second >= succ.pos1.first &&
+        prev.pos2.second >= succ.pos2.first &&
         succ.pos2.second >= prev.pos2.first) {
       // Because conflicts are sorted succ.pos1.first >= prev.pos1.first is
       // guaranteed

--- a/src/datastructure/Route.cpp
+++ b/src/datastructure/Route.cpp
@@ -893,8 +893,14 @@ cda_rail::RouteMap::get_crossing_overlaps(const std::string& train1,
 
     if (const auto& [succ1, succ2, succ_edges] = conflicts.at(i);
         prev1.second >= succ1.first && succ2.second >= prev2.first) {
+      // Because conflicts are sorted succ1.first >= prev1.first is guaranteed
       prev1.second = std::max(prev1.second, succ1.second);
       prev2.first  = std::min(prev2.first, succ2.first);
+      prev2.second = std::max(
+          prev2.second,
+          succ2.second); // usually this should not do anything by the problem
+                         // structure but better safe than sorry because it is
+                         // not 100% guaranteed that this can never happen
       prev_edges.insert(succ_edges.begin(), succ_edges.end());
     } else {
       result.emplace_back(conflicts.at(i));

--- a/src/datastructure/Train.cpp
+++ b/src/datastructure/Train.cpp
@@ -26,12 +26,24 @@ size_t cda_rail::TrainList::add_train(const std::string& name, int length,
    *
    * @return The index of the train in the list of trains.
    */
-  if (has_train(name)) {
+
+  return add_train({name, length, max_speed, acceleration, deceleration, tim});
+}
+
+size_t cda_rail::TrainList::add_train(const Train& train) {
+  /**
+   * Add a train to the list of trains.
+   *
+   * @param train The train to be added.
+   *
+   * @return The index of the train in the list of trains.
+   */
+  if (has_train(train.name)) {
     throw exceptions::ConsistencyException("Train already exists.");
   }
-  trains.emplace_back(name, length, max_speed, acceleration, deceleration, tim);
-  train_name_to_index[name] = trains.size() - 1;
-  return train_name_to_index[name];
+  trains.emplace_back(train);
+  train_name_to_index[train.name] = trains.size() - 1;
+  return train_name_to_index[train.name];
 }
 
 size_t cda_rail::TrainList::get_train_index(const std::string& name) const {

--- a/src/datastructure/Train.cpp
+++ b/src/datastructure/Train.cpp
@@ -42,8 +42,9 @@ size_t cda_rail::TrainList::add_train(const Train& train) {
     throw exceptions::ConsistencyException("Train already exists.");
   }
   trains.emplace_back(train);
-  train_name_to_index[train.name] = trains.size() - 1;
-  return train_name_to_index[train.name];
+  const size_t idx                = trains.size() - 1;
+  train_name_to_index[train.name] = idx;
+  return idx;
 }
 
 size_t cda_rail::TrainList::get_train_index(const std::string& name) const {

--- a/test/test_gen_po_movingblock_mip_solver.cpp
+++ b/test/test_gen_po_movingblock_mip_solver.cpp
@@ -195,11 +195,11 @@ TEST(GenPOMovingBlockMIPSolver, PrivateFillFunctions) {
   // Test if stop data was set correctly
 
   const auto& tr_stop_data = solver.tr_stop_data;
-  EXPECT_EQ(tr_stop_data.size(), 2);
+  ASSERT_EQ(tr_stop_data.size(), 2);
   const auto& tr_1_data = tr_stop_data.at(0);
   const auto& tr_2_data = tr_stop_data.at(1);
-  EXPECT_EQ(tr_1_data.size(), 2);
-  EXPECT_EQ(tr_2_data.size(), 1);
+  ASSERT_EQ(tr_1_data.size(), 2);
+  ASSERT_EQ(tr_2_data.size(), 1);
   const auto& tr_1_1_data = tr_1_data.at(0);
   const auto& tr_1_2_data = tr_1_data.at(1);
   const auto& tr_2_1_data = tr_2_data.at(0);
@@ -283,7 +283,7 @@ TEST(GenPOMovingBlockMIPSolver, PrivateFillFunctions) {
   // Test if velocity data was set correctly
   const auto& vel_data = solver.velocity_extensions;
 
-  EXPECT_EQ(vel_data.size(), 2);
+  ASSERT_EQ(vel_data.size(), 2);
   const auto& vel_data_1 = vel_data.at(0);
   const auto& vel_data_2 = vel_data.at(1);
 

--- a/test/test_general_performance_optimization_instances.cpp
+++ b/test/test_general_performance_optimization_instances.cpp
@@ -1615,6 +1615,29 @@ TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
   EXPECT_EQ(tr13_reverse_2.first, 30);
   EXPECT_EQ(tr13_reverse_2.second, 140);
   EXPECT_EQ(tr13_reverse_e, std::unordered_set<size_t>({e01, e12}));
+
+  const auto tr12_crossing = instance.get_crossing_overlaps("tr1", "tr2");
+  EXPECT_EQ(tr12_crossing.size(), 1);
+  // equal to ttd12 conflict
+  const auto& [tr12_crossing_1, tr12_crossing_2, tr12_crossing_e] =
+      tr12_crossing.at(0);
+  EXPECT_EQ(tr12_crossing_1.first, 100);
+  EXPECT_EQ(tr12_crossing_1.second, 130);
+  EXPECT_EQ(tr12_crossing_2.first, 100);
+  EXPECT_EQ(tr12_crossing_2.second, 140);
+  EXPECT_EQ(tr12_crossing_e, std::unordered_set<size_t>({e12, e23, e24}));
+
+  const auto tr13_crossing = instance.get_crossing_overlaps("tr1", "tr3");
+  EXPECT_EQ(tr13_crossing.size(), 1);
+  // equal to ttd13 and reverse13 merged
+  const auto& [tr13_crossing_1, tr13_crossing_2, tr13_crossing_e] =
+      tr13_crossing.at(0);
+  EXPECT_EQ(tr13_crossing_1.first, 0);
+  EXPECT_EQ(tr13_crossing_1.second, 130);
+  EXPECT_EQ(tr13_crossing_2.first, 0);
+  EXPECT_EQ(tr13_crossing_2.second, 140);
+  EXPECT_EQ(tr13_crossing_e,
+            std::unordered_set<size_t>({e01, e12, e12, e23, e24}));
 }
 
 // NOLINTEND (clang-analyzer-deadcode.DeadStores)

--- a/test/test_general_performance_optimization_instances.cpp
+++ b/test/test_general_performance_optimization_instances.cpp
@@ -1574,69 +1574,65 @@ TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
 
   const auto tr12_parallel = instance.get_parallel_overlaps("tr1", "tr2");
   EXPECT_EQ(tr12_parallel.size(), 1);
-  const auto& [tr12_parallel_1, tr12_parallel_2, tr12_parallel_e] =
-      tr12_parallel.at(0);
-  EXPECT_EQ(tr12_parallel_1.first, 0);
-  EXPECT_EQ(tr12_parallel_1.second, 110);
-  EXPECT_EQ(tr12_parallel_2.first, 0);
-  EXPECT_EQ(tr12_parallel_2.second, 110);
-  EXPECT_EQ(tr12_parallel_e, std::unordered_set<size_t>({e01, e12}));
+  const auto& tr12_parallel_0 = tr12_parallel.at(0);
+  EXPECT_EQ(tr12_parallel_0.pos1.first, 0);
+  EXPECT_EQ(tr12_parallel_0.pos1.second, 110);
+  EXPECT_EQ(tr12_parallel_0.pos2.first, 0);
+  EXPECT_EQ(tr12_parallel_0.pos2.second, 110);
+  EXPECT_EQ(tr12_parallel_0.edges, std::unordered_set<size_t>({e01, e12}));
 
   const auto tr13_parallel = instance.get_parallel_overlaps("tr1", "tr3");
   EXPECT_TRUE(tr13_parallel.empty());
 
   const auto tr12_ttd = instance.get_ttd_overlaps("tr1", "tr2");
   EXPECT_EQ(tr12_ttd.size(), 1);
-  const auto& [tr12_ttd_1, tr12_ttd_2, tr12_ttd_e] = tr12_ttd.at(0);
-  EXPECT_EQ(tr12_ttd_1.first, 100);
-  EXPECT_EQ(tr12_ttd_1.second, 130);
-  EXPECT_EQ(tr12_ttd_2.first, 100);
-  EXPECT_EQ(tr12_ttd_2.second, 140);
-  EXPECT_EQ(tr12_ttd_e, std::unordered_set<size_t>({e12, e23, e24}));
+  const auto& tr12_ttd_0 = tr12_ttd.at(0);
+  EXPECT_EQ(tr12_ttd_0.pos1.first, 100);
+  EXPECT_EQ(tr12_ttd_0.pos1.second, 130);
+  EXPECT_EQ(tr12_ttd_0.pos2.first, 100);
+  EXPECT_EQ(tr12_ttd_0.pos2.second, 140);
+  EXPECT_EQ(tr12_ttd_0.edges, std::unordered_set<size_t>({e12, e23, e24}));
 
   const auto tr13_ttd = instance.get_ttd_overlaps("tr1", "tr3");
   EXPECT_EQ(tr13_ttd.size(), 1);
-  const auto& [tr13_ttd_1, tr13_ttd_2, tr13_ttd_e] = tr13_ttd.at(0);
-  EXPECT_EQ(tr13_ttd_1.first, 100);
-  EXPECT_EQ(tr13_ttd_1.second, 130);
-  EXPECT_EQ(tr13_ttd_2.first, 0);
-  EXPECT_EQ(tr13_ttd_2.second, 40);
-  EXPECT_EQ(tr13_ttd_e, std::unordered_set<size_t>({e12, e23, e24}));
+  const auto& tr13_ttd_0 = tr13_ttd.at(0);
+  EXPECT_EQ(tr13_ttd_0.pos1.first, 100);
+  EXPECT_EQ(tr13_ttd_0.pos1.second, 130);
+  EXPECT_EQ(tr13_ttd_0.pos2.first, 0);
+  EXPECT_EQ(tr13_ttd_0.pos2.second, 40);
+  EXPECT_EQ(tr13_ttd_0.edges, std::unordered_set<size_t>({e12, e23, e24}));
 
   const auto tr12_reverse = instance.get_reverse_overlaps("tr1", "tr2");
   EXPECT_TRUE(tr12_reverse.empty());
 
   const auto tr13_reverse = instance.get_reverse_overlaps("tr1", "tr3");
   EXPECT_EQ(tr13_reverse.size(), 1);
-  const auto& [tr13_reverse_1, tr13_reverse_2, tr13_reverse_e] =
-      tr13_reverse.at(0);
-  EXPECT_EQ(tr13_reverse_1.first, 0);
-  EXPECT_EQ(tr13_reverse_1.second, 110);
-  EXPECT_EQ(tr13_reverse_2.first, 30);
-  EXPECT_EQ(tr13_reverse_2.second, 140);
-  EXPECT_EQ(tr13_reverse_e, std::unordered_set<size_t>({e01, e12}));
+  const auto& tr13_reverse_0 = tr13_reverse.at(0);
+  EXPECT_EQ(tr13_reverse_0.pos1.first, 0);
+  EXPECT_EQ(tr13_reverse_0.pos1.second, 110);
+  EXPECT_EQ(tr13_reverse_0.pos2.first, 30);
+  EXPECT_EQ(tr13_reverse_0.pos2.second, 140);
+  EXPECT_EQ(tr13_reverse_0.edges, std::unordered_set<size_t>({e01, e12}));
 
   const auto tr12_crossing = instance.get_crossing_overlaps("tr1", "tr2");
   EXPECT_EQ(tr12_crossing.size(), 1);
   // equal to ttd12 conflict
-  const auto& [tr12_crossing_1, tr12_crossing_2, tr12_crossing_e] =
-      tr12_crossing.at(0);
-  EXPECT_EQ(tr12_crossing_1.first, 100);
-  EXPECT_EQ(tr12_crossing_1.second, 130);
-  EXPECT_EQ(tr12_crossing_2.first, 100);
-  EXPECT_EQ(tr12_crossing_2.second, 140);
-  EXPECT_EQ(tr12_crossing_e, std::unordered_set<size_t>({e12, e23, e24}));
+  const auto& tr12_crossing_0 = tr12_crossing.at(0);
+  EXPECT_EQ(tr12_crossing_0.pos1.first, 100);
+  EXPECT_EQ(tr12_crossing_0.pos1.second, 130);
+  EXPECT_EQ(tr12_crossing_0.pos2.first, 100);
+  EXPECT_EQ(tr12_crossing_0.pos2.second, 140);
+  EXPECT_EQ(tr12_crossing_0.edges, std::unordered_set<size_t>({e12, e23, e24}));
 
   const auto tr13_crossing = instance.get_crossing_overlaps("tr1", "tr3");
   EXPECT_EQ(tr13_crossing.size(), 1);
   // equal to ttd13 and reverse13 merged
-  const auto& [tr13_crossing_1, tr13_crossing_2, tr13_crossing_e] =
-      tr13_crossing.at(0);
-  EXPECT_EQ(tr13_crossing_1.first, 0);
-  EXPECT_EQ(tr13_crossing_1.second, 130);
-  EXPECT_EQ(tr13_crossing_2.first, 0);
-  EXPECT_EQ(tr13_crossing_2.second, 140);
-  EXPECT_EQ(tr13_crossing_e,
+  const auto& tr13_crossing_0 = tr13_crossing.at(0);
+  EXPECT_EQ(tr13_crossing_0.pos1.first, 0);
+  EXPECT_EQ(tr13_crossing_0.pos1.second, 130);
+  EXPECT_EQ(tr13_crossing_0.pos2.first, 0);
+  EXPECT_EQ(tr13_crossing_0.pos2.second, 140);
+  EXPECT_EQ(tr13_crossing_0.edges,
             std::unordered_set<size_t>({e01, e12, e12, e23, e24}));
 }
 

--- a/test/test_general_performance_optimization_instances.cpp
+++ b/test/test_general_performance_optimization_instances.cpp
@@ -1527,4 +1527,94 @@ TEST(GeneralPerformanceOptimizationInstances, RASPaths) {
   }
 }
 
+TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
+  cda_rail::instances::GeneralPerformanceOptimizationInstance instance;
+
+  // Create simple network with parallel edges
+  const auto v0 = instance.n().add_vertex("v0", cda_rail::VertexType::TTD);
+  const auto v1 = instance.n().add_vertex("v1", cda_rail::VertexType::TTD);
+  const auto v2 = instance.n().add_vertex("v2", cda_rail::VertexType::NoBorder);
+  const auto v3 = instance.n().add_vertex("v3", cda_rail::VertexType::TTD);
+  const auto v4 = instance.n().add_vertex("v4", cda_rail::VertexType::TTD);
+
+  const auto e01 = instance.n().add_edge(v0, v1, 100, 20, true);
+  const auto e12 = instance.n().add_edge(v1, v2, 10, 20, false);
+  const auto e23 = instance.n().add_edge(v2, v3, 20, 20, false);
+  const auto e24 = instance.n().add_edge(v2, v4, 30, 20, false);
+  const auto e42 = instance.n().add_edge(v4, v2, 30, 20, false);
+  const auto e21 = instance.n().add_edge(v2, v1, 10, 20, false);
+  const auto e10 = instance.n().add_edge(v1, v0, 100, 20, true);
+
+  instance.n().add_successor(e01, e12);
+  instance.n().add_successor(e12, e23);
+  instance.n().add_successor(e12, e24);
+  instance.n().add_successor(e42, e21);
+  instance.n().add_successor(e21, e10);
+
+  const auto tr1 = instance.add_train("tr1", 50, 20, 1, 2, {0, 60}, 20, v0,
+                                      {300, 360}, 0, v3);
+  const auto tr2 = instance.add_train("tr2", 50, 20, 1, 2, {0, 60}, 20, v0,
+                                      {300, 360}, 0, v4);
+  const auto tr3 = instance.add_train("tr3", 50, 20, 1, 2, {0, 60}, 20, v4,
+                                      {300, 360}, 0, v0);
+
+  instance.add_empty_route("tr1");
+  instance.add_empty_route("tr2");
+  instance.add_empty_route("tr3");
+
+  instance.push_back_edge_to_route("tr1", e01);
+  instance.push_back_edge_to_route("tr1", e12);
+  instance.push_back_edge_to_route("tr1", e23);
+  instance.push_back_edge_to_route("tr2", e01);
+  instance.push_back_edge_to_route("tr2", e12);
+  instance.push_back_edge_to_route("tr2", e24);
+  instance.push_back_edge_to_route("tr3", e42);
+  instance.push_back_edge_to_route("tr3", e21);
+  instance.push_back_edge_to_route("tr3", e10);
+
+  const auto tr12_parallel = instance.get_parallel_overlaps("tr1", "tr2");
+  EXPECT_EQ(tr12_parallel.size(), 1);
+  const auto& [tr12_parallel_1, tr12_parallel_2, tr12_parallel_e] =
+      tr12_parallel.at(0);
+  EXPECT_EQ(tr12_parallel_1.first, 0);
+  EXPECT_EQ(tr12_parallel_1.second, 110);
+  EXPECT_EQ(tr12_parallel_2.first, 0);
+  EXPECT_EQ(tr12_parallel_2.second, 110);
+  EXPECT_EQ(tr12_parallel_e, std::unordered_set<size_t>({e01, e12}));
+
+  const auto tr13_parallel = instance.get_parallel_overlaps("tr1", "tr3");
+  EXPECT_TRUE(tr13_parallel.empty());
+
+  const auto tr12_ttd = instance.get_ttd_overlaps("tr1", "tr2");
+  EXPECT_EQ(tr12_ttd.size(), 1);
+  const auto& [tr12_ttd_1, tr12_ttd_2, tr12_ttd_e] = tr12_ttd.at(0);
+  EXPECT_EQ(tr12_ttd_1.first, 100);
+  EXPECT_EQ(tr12_ttd_1.second, 130);
+  EXPECT_EQ(tr12_ttd_2.first, 100);
+  EXPECT_EQ(tr12_ttd_2.second, 140);
+  EXPECT_EQ(tr12_ttd_e, std::unordered_set<size_t>({e12, e23, e24}));
+
+  const auto tr13_ttd = instance.get_ttd_overlaps("tr1", "tr3");
+  EXPECT_EQ(tr13_ttd.size(), 1);
+  const auto& [tr13_ttd_1, tr13_ttd_2, tr13_ttd_e] = tr13_ttd.at(0);
+  EXPECT_EQ(tr13_ttd_1.first, 100);
+  EXPECT_EQ(tr13_ttd_1.second, 130);
+  EXPECT_EQ(tr13_ttd_2.first, 0);
+  EXPECT_EQ(tr13_ttd_2.second, 40);
+  EXPECT_EQ(tr13_ttd_e, std::unordered_set<size_t>({e12, e23, e24}));
+
+  const auto tr12_reverse = instance.get_reverse_overlaps("tr1", "tr2");
+  EXPECT_TRUE(tr12_reverse.empty());
+
+  const auto tr13_reverse = instance.get_reverse_overlaps("tr1", "tr3");
+  EXPECT_EQ(tr13_reverse.size(), 1);
+  const auto& [tr13_reverse_1, tr13_reverse_2, tr13_reverse_e] =
+      tr13_reverse.at(0);
+  EXPECT_EQ(tr13_reverse_1.first, 0);
+  EXPECT_EQ(tr13_reverse_1.second, 110);
+  EXPECT_EQ(tr13_reverse_2.first, 30);
+  EXPECT_EQ(tr13_reverse_2.second, 140);
+  EXPECT_EQ(tr13_reverse_e, std::unordered_set<size_t>({e01, e12}));
+}
+
 // NOLINTEND (clang-analyzer-deadcode.DeadStores)

--- a/test/test_general_performance_optimization_instances.cpp
+++ b/test/test_general_performance_optimization_instances.cpp
@@ -1633,7 +1633,7 @@ TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
   EXPECT_EQ(tr13_crossing_0.pos2.first, 0);
   EXPECT_EQ(tr13_crossing_0.pos2.second, 140);
   EXPECT_EQ(tr13_crossing_0.edges,
-            std::unordered_set<size_t>({e01, e12, e12, e23, e24}));
+            std::unordered_set<size_t>({e01, e12, e23, e24}));
 }
 
 TEST(GeneralPerformanceOptimizationInstances, CrossingOverlapNoUnion) {

--- a/test/test_general_performance_optimization_instances.cpp
+++ b/test/test_general_performance_optimization_instances.cpp
@@ -1573,7 +1573,7 @@ TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
   instance.push_back_edge_to_route("tr3", e10);
 
   const auto tr12_parallel = instance.get_parallel_overlaps("tr1", "tr2");
-  EXPECT_EQ(tr12_parallel.size(), 1);
+  ASSERT_EQ(tr12_parallel.size(), 1);
   const auto& tr12_parallel_0 = tr12_parallel.at(0);
   EXPECT_EQ(tr12_parallel_0.pos1.first, 0);
   EXPECT_EQ(tr12_parallel_0.pos1.second, 110);
@@ -1585,7 +1585,7 @@ TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
   EXPECT_TRUE(tr13_parallel.empty());
 
   const auto tr12_ttd = instance.get_ttd_overlaps("tr1", "tr2");
-  EXPECT_EQ(tr12_ttd.size(), 1);
+  ASSERT_EQ(tr12_ttd.size(), 1);
   const auto& tr12_ttd_0 = tr12_ttd.at(0);
   EXPECT_EQ(tr12_ttd_0.pos1.first, 100);
   EXPECT_EQ(tr12_ttd_0.pos1.second, 130);
@@ -1594,7 +1594,7 @@ TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
   EXPECT_EQ(tr12_ttd_0.edges, std::unordered_set<size_t>({e12, e23, e24}));
 
   const auto tr13_ttd = instance.get_ttd_overlaps("tr1", "tr3");
-  EXPECT_EQ(tr13_ttd.size(), 1);
+  ASSERT_EQ(tr13_ttd.size(), 1);
   const auto& tr13_ttd_0 = tr13_ttd.at(0);
   EXPECT_EQ(tr13_ttd_0.pos1.first, 100);
   EXPECT_EQ(tr13_ttd_0.pos1.second, 130);
@@ -1606,7 +1606,7 @@ TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
   EXPECT_TRUE(tr12_reverse.empty());
 
   const auto tr13_reverse = instance.get_reverse_overlaps("tr1", "tr3");
-  EXPECT_EQ(tr13_reverse.size(), 1);
+  ASSERT_EQ(tr13_reverse.size(), 1);
   const auto& tr13_reverse_0 = tr13_reverse.at(0);
   EXPECT_EQ(tr13_reverse_0.pos1.first, 0);
   EXPECT_EQ(tr13_reverse_0.pos1.second, 110);
@@ -1615,7 +1615,7 @@ TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
   EXPECT_EQ(tr13_reverse_0.edges, std::unordered_set<size_t>({e01, e12}));
 
   const auto tr12_crossing = instance.get_crossing_overlaps("tr1", "tr2");
-  EXPECT_EQ(tr12_crossing.size(), 1);
+  ASSERT_EQ(tr12_crossing.size(), 1);
   // equal to ttd12 conflict
   const auto& tr12_crossing_0 = tr12_crossing.at(0);
   EXPECT_EQ(tr12_crossing_0.pos1.first, 100);
@@ -1625,7 +1625,7 @@ TEST(GeneralPerformanceOptimizationInstances, Overlaps) {
   EXPECT_EQ(tr12_crossing_0.edges, std::unordered_set<size_t>({e12, e23, e24}));
 
   const auto tr13_crossing = instance.get_crossing_overlaps("tr1", "tr3");
-  EXPECT_EQ(tr13_crossing.size(), 1);
+  ASSERT_EQ(tr13_crossing.size(), 1);
   // equal to ttd13 and reverse13 merged
   const auto& tr13_crossing_0 = tr13_crossing.at(0);
   EXPECT_EQ(tr13_crossing_0.pos1.first, 0);
@@ -1676,7 +1676,7 @@ TEST(GeneralPerformanceOptimizationInstances, CrossingOverlapNoUnion) {
   instance.push_back_edge_to_route("tr2", e10);
 
   const auto tr12_crossing = instance.get_crossing_overlaps("tr1", "tr2");
-  EXPECT_EQ(tr12_crossing.size(), 2);
+  ASSERT_EQ(tr12_crossing.size(), 2);
   const auto& tr12_crossing_0 = tr12_crossing.at(0);
   EXPECT_EQ(tr12_crossing_0.pos1.first, 0);
   EXPECT_EQ(tr12_crossing_0.pos1.second, 100);

--- a/test/test_railwaynetwork.cpp
+++ b/test/test_railwaynetwork.cpp
@@ -4145,6 +4145,36 @@ TEST(RouteFunctionality, FirstPosOnEdge) {
   EXPECT_EQ(p2.value_or(-1), 1);
 }
 
+TEST(RouteFunctionality, LastPosOnEdge) {
+  cda_rail::Network network;
+  const auto v0 = network.add_vertex("v0", cda_rail::VertexType::NoBorder);
+  const auto v1 = network.add_vertex("v1", cda_rail::VertexType::VSS);
+  const auto v2 = network.add_vertex("v2", cda_rail::VertexType::TTD);
+
+  const auto e0 = network.add_edge("v0", "v1", 1, 2, false, 0);
+  const auto e1 = network.add_edge("v1", "v2", 3, 4, true, 1.5);
+  const auto e2 = network.add_edge("v1", "v0", 1, 2, false, 0);
+
+  network.add_successor(e0, e1);
+
+  cda_rail::Route route;
+  route.push_back_edge(e0, network);
+  route.push_back_edge(e1, network);
+
+  const auto p1 = route.get_last_pos_on_edges({e0, e1, e2}, network);
+  const auto p2 = route.get_last_pos_on_edges({e1}, network);
+  const auto p3 = route.get_last_pos_on_edges({e2}, network);
+  const auto p4 = route.get_last_pos_on_edges({e0}, network);
+
+  EXPECT_TRUE(p1.has_value());
+  EXPECT_TRUE(p2.has_value());
+  EXPECT_FALSE(p3.has_value());
+  EXPECT_TRUE(p4.has_value());
+  EXPECT_EQ(p1.value_or(-1), 4);
+  EXPECT_EQ(p2.value_or(-1), 4);
+  EXPECT_EQ(p4.value_or(-1), 1);
+}
+
 TEST(RouteMapFunctionality, EmptyConflicts) {
   auto network = cda_rail::Network::import_network(
       "./example-networks/SimpleStation/network/");

--- a/test/test_railwaynetwork.cpp
+++ b/test/test_railwaynetwork.cpp
@@ -4087,19 +4087,19 @@ TEST(Functionality, NetworkNextTTD) {
   const auto routing2 =
       network.all_paths_ending_at_ttd(v2_v3a, ttd_sections, v9a);
   // Expect only (v3a_v4a) as the only path
-  EXPECT_EQ(routing2.size(), 1);
+  ASSERT_EQ(routing2.size(), 1);
   EXPECT_EQ(routing2.at(0), std::vector<size_t>({v3a_v4a}));
 
   const auto routing3 =
       network.all_paths_ending_at_ttd(v3a_v4a, ttd_sections, v9b);
   // Expect only (v4a_v5, v5_v6)
-  EXPECT_EQ(routing3.size(), 1);
+  ASSERT_EQ(routing3.size(), 1);
   EXPECT_EQ(routing3.at(0), std::vector<size_t>({v4a_v5, v5_v6}));
 
   const auto routing4 =
       network.all_paths_ending_at_ttd(v5_v6, ttd_sections, v9b);
   // Expect only (v6_v7, v7_v8b, v8b_v9b)
-  EXPECT_EQ(routing4.size(), 1);
+  ASSERT_EQ(routing4.size(), 1);
   EXPECT_EQ(routing4.at(0), std::vector<size_t>({v6_v7, v7_v8b, v8b_v9b}));
 }
 


### PR DESCRIPTION
## Description

This PR adds some general helper functions that might be useful in the future. They all arose from a different, private project.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overlap detection between trains: parallel, time-dependent (TTD), reverse, and combined crossing overlaps
  * Route position lookups constrained to specified edges (first/last) and last-stop position retrieval
  * Undirected track indexing (map edge to track)
  * Bulk train insertion using pre-built train objects
  * Problem-instance API extended with overlap query methods

* **Tests**
  * New and expanded tests for overlaps, track indexing, route position lookups, and route management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->