### PR TITLE
Run ctest tests in parallel

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Debug
       - name: Test
-        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:3 --timeout 750
+        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:2 --timeout 750 --parallel 4
   cpp-macos-latest:
     name: cpp-macos-latest
     runs-on: macos-latest
@@ -105,7 +105,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Debug
       - name: Test
-        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:3 --timeout 750
+        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:2 --timeout 750 --parallel 4
   cpp-windows-latest:
     name: cpp-windows-latest
     runs-on: windows-latest
@@ -154,7 +154,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Debug
       - name: Test
-        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:3 --timeout 750
+        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:2 --timeout 750 --parallel 4
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
@@ -186,7 +186,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Debug --target rail_test
       - name: Test
-        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:3 --timeout 750
+        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:2 --timeout 750 --parallel 4
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Debug --target rail_test
       - name: Test
-        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:2 --timeout 750 --parallel 4
+        run: ctest -C Debug --output-on-failure --test-dir build --repeat until-pass:2 --timeout 750
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
## Description

This PR updates the C++ CI on github. It aims to reduce the time needed for the CI to finish by allowing multiple tests to be executed in parallel. At the same time the machines (ubuntu, windows, mac) are still sequentially because there are only two gurobi licenses available to be used at the same time.

## Checklist:

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI test execution: reduced required consecutive pass count and enabled parallel test runs to speed up pipeline and improve efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->